### PR TITLE
using the display function to hide on smaller screens

### DIFF
--- a/site/views/layouts/main.handlebars
+++ b/site/views/layouts/main.handlebars
@@ -19,35 +19,35 @@
 <body>
     <div class="container bg-light">
         <!--  Menu -->
-        <div>
-            <nav class="navbar navbar-expand-lg bg-light navbar-light">
-                <div class="container-fluid">
-                    <!-- brand icon -->
-                    <a class="navbar-brand" href="#">
-                        <img src="/img/logo.png" alt="Avatar Logo" style="width:40px;" class="rounded-pill">
-                    </a>
-                    <!-- menu toggle -->
-                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
-                        aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-                        <span class="navbar-toggler-icon"></span>
-                    </button>
-                    <!-- Menu Items -->
-                    <div class="collapse navbar-collapse" id="navbarNav">
-                        <ul class="navbar-nav">
-                            <li class="nav-item">
-                                <a class="nav-link" href="/">Home</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link" href="/about">About</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link" href="/contact">Contact</a>
-                            </li>
-                        </ul>
-                    </div>
+
+        <nav class="navbar navbar-expand-lg bg-light navbar-light">
+            <div class="container-fluid">
+                <!-- brand icon -->
+                <a class="navbar-brand" href="#">
+                    <img src="/img/logo.png" alt="Avatar Logo" style="width:40px;" class="rounded-pill">
+                </a>
+                <!-- menu toggle -->
+                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
+                    aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
+                <!-- Menu Items -->
+                <div class="collapse navbar-collapse" id="navbarNav">
+                    <ul class="navbar-nav">
+                        <li class="nav-item">
+                            <a class="nav-link" href="/">Home</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="/about">About</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="/contact">Contact</a>
+                        </li>
+                    </ul>
                 </div>
-            </nav>
-        </div>
+            </div>
+        </nav>
+
         <!-- Main Content -->
         <div class="row border p-3">
             <div class="col-9">
@@ -65,7 +65,7 @@
 
                 {{{body}}}
             </div>
-            <div class="col-3">
+            <div class="col d-none d-sm-block">
                 <img src="/img/logo.png" class="img-thumbnail float-end" alt="" srcset="">
             </div>
         </div>

--- a/site/views/layouts/main.handlebars
+++ b/site/views/layouts/main.handlebars
@@ -25,6 +25,7 @@
                 <!-- brand icon -->
                 <a class="navbar-brand" href="#">
                     <img src="/img/logo.png" alt="Avatar Logo" style="width:40px;" class="rounded-pill">
+                    Meadowlark
                 </a>
                 <!-- menu toggle -->
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
@@ -50,7 +51,7 @@
 
         <!-- Main Content -->
         <div class="row border p-3">
-            <div class="col-9">
+            <div class="col">
 
                 <!-- Container for Flash Alerts -->
                 <div id="alertContainer">
@@ -64,9 +65,6 @@
                 </div>
 
                 {{{body}}}
-            </div>
-            <div class="col d-none d-sm-block">
-                <img src="/img/logo.png" class="img-thumbnail float-end" alt="" srcset="">
             </div>
         </div>
     </div>


### PR DESCRIPTION
There is a way to hide elements based on screen width in bootstrap[^1].  This I tried this on the div and it did git rid of the logo on small screens.  Problem is the column still takes up the screen space.  So in the interest of expediency, probably best to just remove the image altogether.  The image really just takes up a lot of space anyway.  Looked better on the main page where there was very little else displayed.


[^1]: https://getbootstrap.com/docs/5.1/utilities/display/#how-it-works